### PR TITLE
Fix a crash caused by dynamic variables

### DIFF
--- a/resource_ldap_object.go
+++ b/resource_ldap_object.go
@@ -362,7 +362,13 @@ func readLDAPObjectImpl(d *schema.ResourceData, meta interface{}, updateState bo
 
 // computes the hash of the map representing an attribute in the attributes set
 func attributeHash(v interface{}) int {
-	m := v.(map[string]interface{})
+	m, ok := v.(map[string]interface{})
+
+	// In case of calculated fields, v might be nil.
+	if !ok {
+		return hashcode.String("nil")
+	}
+
 	var buffer bytes.Buffer
 	buffer.WriteString("map {")
 	for k, v := range m {


### PR DESCRIPTION
When this provider is used and another resource is providing values for a resource managed by this provider, attributeHash() might be given nil. Instead of panicking on the type assertion, hash the "nil" value instead. After the plan runs, the values are known and properly submitted to LDAP.

A particular use case: when managing VMs though terraform-provider-libvirt, and managing DHCPd through LDAP using this provider. When a machine is created, a random MAC address is generated. This same MAC address is needed to properly instruct DHCPd to give out a fixed IP and thus using terraform, it can be queried from the libvirt resource. The alternative is to hardcode the MAC addresses but this should not be necessary at al.