### PR TITLE
remove use_tls attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ EOF
 provider "ldap" {
   ldap_host     = "ldap.example.org"
   ldap_port     = 389
-  use_tls       = true
   bind_user     = "cn=admin,dc=example,dc=com"
   bind_password = "admin"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,4 +44,3 @@ provider "ldap" {
 - **start_tls** (Boolean) Upgrade TLS to secure the connection (default: false).
 - **tls** (Boolean) Enable TLS encryption for LDAP (LDAPS) (default: false).
 - **tls_insecure** (Boolean) Don't verify server TLS certificate (default: false).
-- **use_tls** (Boolean, Deprecated) Use TLS to secure the connection (default: true).

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -21,12 +21,6 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("LDAP_PORT", 389),
 				Description: "The LDAP protocol port (default: 389).",
 			},
-			"use_tls": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Use TLS to secure the connection (default: true).",
-				Deprecated:  "use_tls attribute has been rename to start_tls.",
-			},
 			"bind_user": {
 				Type:        schema.TypeString,
 				Required:    true,


### PR DESCRIPTION
`use_tls` attribute has been rename to `start_tls`.