### PR TITLE
Adding hidden_attributes option to resource

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ description: |-
 
 # LDAP Provider
 
-The LDAP provider provides resources to interact with a LDAP object.
+The LDAP provider provides resources to interact with a LDAP object, includes the ability to update attributes that cannot be read by the client.
 
 ## Example Usage
 

--- a/docs/resources/object.md
+++ b/docs/resources/object.md
@@ -34,6 +34,7 @@ resource "ldap_object" "a123456" {
     { homeDirectory = "/home/jdoe" },
     { loginShell = "/bin/bash" }
   ]
+  hidden_attributes = ["userPassword"]
 }
 ```
 
@@ -48,6 +49,7 @@ resource "ldap_object" "a123456" {
 ### Optional
 
 - **attributes** (Set of Map of String) The map of attributes of this object; each attribute can be multi-valued.
+- **hidden_attributes** (Set of String) The set of attributes that can't be read from the LDAP server (e.g. userPassword). Attributes present in this list will be updated using the replace method, even if the attribute does not exists in the ldap server.
 - **id** (String) The ID of this resource.
 
 ## Import

--- a/examples/resources/ldap_object/resource.tf
+++ b/examples/resources/ldap_object/resource.tf
@@ -19,4 +19,5 @@ resource "ldap_object" "a123456" {
     { homeDirectory = "/home/jdoe" },
     { loginShell = "/bin/bash" }
   ]
+  hidden_attributes = ["userPassword"]
 }

--- a/internal/provider/resource_ldap_object_test.go
+++ b/internal/provider/resource_ldap_object_test.go
@@ -126,5 +126,6 @@ resource "ldap_object" "jdoe" {
    	{ homeDirectory = "/home/jdoe"},
    	{ loginShell    = "/bin/bash" }
 	]
+
 }
 `

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -55,4 +55,6 @@ resource "ldap_object" "a123456" {
     { homeDirectory = "/home/jdoe" },
     { loginShell = "/bin/bash" }
   ]
+
+  hidden_attributes = ["userPassword"]
 }


### PR DESCRIPTION
In our environment we have disabled the possibility of reading some attributes from the LDAP server, such as userPassword. This causes the LDAP provider to perform Add operations when it should perform Replace operations on these attributes.

In order to solve this problem we created the optional field "hidden_attributes", which describes attributes that at the time of update will perform the replace operation even if the ldap server does not return the described attribute.